### PR TITLE
Update Grammar on Gemini Extensions Call

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The Canva Model Context Protocol (MCP) is a Gemini CLI extension that bridges th
 Install the extension with a single command:
 
 ```bash
-gemini extension install https://github.com/canva-sdks/canva-gemini-extension
+gemini extensions install https://github.com/canva-sdks/canva-gemini-extension
 ```
 
 ## What It Does

--- a/gemini-extension/GEMINI.md
+++ b/gemini-extension/GEMINI.md
@@ -7,7 +7,7 @@ The Canva Model Context Protocol (MCP) is a Gemini CLI extension that bridges th
 Install the extension with a single command:
 
 ```bash
-gemini extension install https://github.com/canva-sdks/canva-gemini-extension
+gemini extensions install https://github.com/canva-sdks/canva-gemini-extension
 ```
 
 ## What It Does


### PR DESCRIPTION
Updates the grammar to correctly use the pluralised command for installing the extension as there was a typo. 