### PR TITLE
chore: add description to Canva extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Install the extension with a single command:
 gemini extensions install https://github.com/canva-sdks/canva-gemini-extension
 ```
 
+Once installed, run `gemini` to start Gemini CLI and `/mcp auth canva` to authenticate with Canva.
+
 ## What It Does
 
 **Design Creation & Management**

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,7 @@
 {
   "name": "canva",
   "version": "1.0.0",
+  "description": "Create new Canva designs, auto-fill templates, find existing designs, and export them as PDFs or images.",
   "mcpServers": {
     "Canva": {
       "httpUrl": "https://mcp.canva.com/mcp",


### PR DESCRIPTION
Hi Gemini CLI team member here 👋 

The description field of `gemini-extension.json` is what populates the description of an extension on https://geminicli.com/extensions

Just adding a description to Canva to make it more searchable and discoverable by users 😄 

Will look like this once updated:

<img width="451" height="303" alt="image" src="https://github.com/user-attachments/assets/a1168ad6-41cd-4799-84e9-068d3476acff" />
